### PR TITLE
Vim gutter to show/hide breakpoint markers

### DIFF
--- a/example.gdbinit
+++ b/example.gdbinit
@@ -18,3 +18,12 @@ set vimview-tabs on
 # enable debug mode
 #pi vimView.debug = True
 
+# glboal-symbol is used to find the location of source file when a new objectfile is loaded
+#set vimview-global-symbol main
+
+# show source file in Vim as soon as an object file is loaded in GDB
+set vimview-new-objectfile on
+
+# show/hide breakpoint markers in Vim
+set vimview-new-breakpoint on
+set vimview-delete-breakpoint on

--- a/vimview.py
+++ b/vimview.py
@@ -215,9 +215,9 @@ class VarCursorWord(gdb.Function):
 	cmd = None
 
 	def __init__ (self, name, cmd):
+		super(VarCursorWord, self).__init__ (name)
 		self.name = name
 		self.cmd = cmd
-		super(VarCursorWord, self).__init__ (name)
 
 	def invoke(self, *args):
 		global vimView
@@ -248,10 +248,10 @@ class ParamVimViewOnStop(gdb.Parameter):
 	isHooked = False
 
 	def __init__(self, cmd):
+		super(ParamVimViewOnStop, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_AUTO_BOOLEAN)
 		self.value = False
 		self.set_doc = 'VimView: following frame on stop.'
 		self.show_doc = self.set_doc
-		super(ParamVimViewOnStop, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_AUTO_BOOLEAN)
 
 	def get_set_string(self):
 		if self.value == None:	# auto
@@ -277,10 +277,10 @@ class ParamVimViewOnPrompt(gdb.Parameter):
 	prevHook = gdb.prompt_hook
 
 	def __init__(self, cmd):
+		super(ParamVimViewOnPrompt, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_AUTO_BOOLEAN)
 		self.value = False
 		self.set_doc = 'VimView: following frame on prompt show.'
 		self.show_doc = self.set_doc
-		super(ParamVimViewOnPrompt, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_AUTO_BOOLEAN)
 
 	def get_set_string(self):
 		if self.value == None:	# auto
@@ -303,9 +303,9 @@ class ParamVimViewOnPrompt(gdb.Parameter):
 class ParamServerName(gdb.Parameter):
 	"""This is part of the VimView plugin."""
 	def __init__(self, cmd):
+		super(ParamServerName, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_STRING)
 		self.set_doc = 'VimView: remote vim server name.'
 		self.show_doc = self.set_doc
-		super(ParamServerName, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_STRING)
 
 		global vimView
 		self.value = vimView.serverName
@@ -323,9 +323,9 @@ class ParamServerName(gdb.Parameter):
 class ParamBinaryName(gdb.Parameter):
 	"""This is part of the VimView plugin."""
 	def __init__(self, cmd):
+		super(ParamBinaryName, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_STRING)
 		self.set_doc = 'VimView: vim executable name.'
 		self.show_doc = self.set_doc
-		super(ParamBinaryName, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_STRING)
 
 		global vimView
 		self.value = vimView.binaryName
@@ -343,10 +343,10 @@ class ParamBinaryName(gdb.Parameter):
 class ParamUseTabs(gdb.Parameter):
 	"""This is part of the VimView plugin."""
 	def __init__(self, cmd):
+		super(ParamUseTabs, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_BOOLEAN)
 		self.value = False
 		self.set_doc = 'VimView: open files in tabs.'
 		self.show_doc = self.set_doc
-		super(ParamUseTabs, self).__init__(cmd, gdb.COMMAND_SUPPORT, gdb.PARAM_BOOLEAN)
 
 	def get_set_string(self):
 		global vimView


### PR DESCRIPTION
Changes include:

- minor bug-fixes. Default values for the vimview parameters were set to **on** even if they were initialized to False. So I moved the `super()` calls to the top of the `__init__()` so that the self.value's do not get over-written.

- gdb-vimview now displays the source file in Vim as soon as GDB loads an object file. This is done by  hooking to **`new-objectfile`** event and using **`gdb.lookup_global_symbol()`** to search for a well-known symbol; in my case 'main'. I have added a parameter **`vimview-global-symbol`** if one needs to define a different entry point. This is controlled by parameter **`vimview-new-objectfile`**

- gdb-vimview now shows/hides breakpoint markers when they are set and/deleted. Breakpoints do not need to be in the current buffer. This is controlled by parameters [**`vimview-new-breakpoint, vimview-delete-breakpoint`**]. TBH, only one parameter should suffice, but the way I implemented the GenericHookParameter class kind-of forced my hand. There is definetely room for improvement.

- gdb-vimview now checks if a Vim server is running by using a utility function **`_isVimServerAlive()`**

- updated the example .gdbinit file to reflect the new changes